### PR TITLE
Fix the cancel event function to prevent erroneous close

### DIFF
--- a/src/jquery.uls.core.js
+++ b/src/jquery.uls.core.js
@@ -319,7 +319,7 @@
 		 * On cancel handler for the uls menu
 		 */
 		cancel: function ( e ) {
-			if ( e && this.$element.is( e.target ) ) {
+			if ( e && ( this.$element.is( e.target ) || $.contains( this.$element[0], e.target ) ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Changed the conditions for the cancel event function so that the ULS popup does not close when a descendant element of the trigger is clicked.

Was erroneously merged to gerrit as https://gerrit.wikimedia.org/r/#/c/261810/, I forgot that this was an upstream library.

https://phabricator.wikimedia.org/T122722
